### PR TITLE
SOA Joining Dialogue & Cutscene Fixes

### DIFF
--- a/zdbae/baf/ar0406.baf
+++ b/zdbae/baf/ar0406.baf
@@ -3,7 +3,7 @@ IF
 THEN
 RESPONSE #100
   SetGlobal("ZDBAEExists","GLOBAL",1)
-  CreateCreature("ZDBAE",[2340.1650],5)
+  CreateCreature("ZDBAE",[2340.1650],NE)
   Continue()
 END
 

--- a/zdbae/baf/cut02d.baf
+++ b/zdbae/baf/cut02d.baf
@@ -21,7 +21,6 @@ THEN
   AttackOneRound("Gladiator")  // Gladiator
   AttackOneRound("Gladiator")  // Gladiator
   Kill("Gladiator")  // Gladiator
-  EscapeArea()
   Wait(1)
-  StartCutScene("zdintro")
+  StartCutScene("zdintro")  
 END

--- a/zdbae/baf/zdbcutr.baf
+++ b/zdbae/baf/zdbcutr.baf
@@ -7,6 +7,7 @@ THEN
     SetGlobal("ZDBAE1_CUTSCENE_BREAKABLE","GLOBAL",1)
     SetCutSceneBreakable(TRUE)
     // NOBLE 1
+	ForceSpell("ZDBAE",FLASHY_4)
     DisplayStringPoint([2453.1575],@101) /* ~A drow? Here?~ */
     Wait(1)
     DisplayStringHead("Announcer",@102) /* ~WHAT?! Security, Security!~ */
@@ -32,7 +33,7 @@ THEN
     Wait(2)
     DisplayStringHead("Frankie",@104) /* ~Kill the drow!~ */
     Wait(2)
-    DisplayStringHead("ZDBAE",@105) /* ~Good people I uh... Lets be reasonable about this!~ */
+    DisplayStringHead("ZDBAE",@105) /* ~Good, uh, people. Surely we can resolve this with wit and not...whatever this is?~ */
     Wait(2)
     SetCutSceneBreakable(FALSE)
     ActionOverride("zdfranki", DestroySelf())

--- a/zdbae/baf/zdintro.baf
+++ b/zdbae/baf/zdintro.baf
@@ -3,21 +3,18 @@ IF
 THEN
   RESPONSE #100
   CutSceneId("ZDBAE") // BAE
-  DisplayStringHead("ZDBAE", @106) /* What a wretched waste! How boring and banal this brawl is! Were I to grace these grounds with my talents, tragedy would instead transform into triumph. I would bring power, prestige and panache to this pitiful pit. Someone should displace - dare I say depose - of the dullard who dared to direct such a dreary display. Perhaps... me? */
+  ActionOverride("GladiatorBear",EscapeArea())
+  DisplayStringHead("ZDBAE", @106) /* What a wretched waste! How boring and banal this brawl is! Were I to grace these grounds with my talents, tragedy would instead transform into triumph. I would bring power, prestige and panache to this pitiful pit. */
+  Wait(12)
+  DisplayStringHead("ZDBAE", @111) /* Someone should displace - dare I say depose - of the dullard who dared to direct such a dreary display. Perhaps... me? */
+  Wait(8)
+  DisplayStringPoint([2385.1533], @107) /* You have the right of it. */
   Wait(5)
-  // Fix Nobles with pos
-  DisplayStringHead("NOBLE1", @107) /* You have the right of it. */
-  Wait(2)
-  DisplayStringHead("NOBLE2", @108) /* I have not been entertained! */
-  Wait(2)
-  DisplayStringHead("NOBLE1", @109) /* If you've got a plan, I'm in. Can't be much harder starting a fight than watching one. */
-  Wait(3)
+  DisplayStringPoint([2453.1575], @108) /* I have not been entertained! */
+  Wait(5)
+  DisplayStringPoint([2385.1533], @109) /* If you've got a plan, I'm in. Can't be much harder starting a fight than watching one. */
+  Wait(8)
   DisplayStringHead("ZDBAE", @110) /* Then huddle close my hapless horde. The time of tedium is about to be terminated. */
-  ActionOverride("NOBLE1",MoveToObject("ZDBAE"))
-  ActionOverride("NOBLE2",MoveToObject("ZDBAE"))
-  Wait(3)
-  ActionOverride("NOBLE1",FaceObject("ZDBAE"))
-  ActionOverride("NOBLE2",FaceObject("ZDBAE"))
-  Wait(1)
+  Wait(5)
   StartDialogueNoSet(Player1)
 END

--- a/zdbae/dialog/zdbae.d
+++ b/zdbae/dialog/zdbae.d
@@ -2,32 +2,32 @@ BEGIN ZDBAE
 
 // Joining dialogue
 IF ~!Global("ZDBAE_HOSTILE","GLOBAL",1) Global("ZDBAE_BEGIN","GLOBAL",0) Global("ZDBAE_SHUTUP","GLOBAL",0)~ THEN BEGIN ZDBAE1
-  SAY ~Well, well, well, what whimsical wonder do we witness here? Another face amidst the multitude of mundane mediocrity. You, stand before the ineffable Baeloth the Entertainer.~
+  SAY ~Well, well, well, what whimsical wonder do we witness here? Another face amidst the multitude of mundane mediocrity. You stand before the ineffable Baeloth the Entertainer.~
   IF ~~ THEN REPLY ~Well met, I am <CHARNAME>.~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1)~ GOTO ZDBAE2
-  IF ~Global("BA_BEGIN","GLOBAL",1)~ THEN REPLY ~Baeloth! Do you remember me?~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1)~ GOTO ZDBAE3
-  IF ~~ THEN REPLY ~Die, drow!~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1) SetGlobal("ZDBAE_REVEAL","GLOBAL",1)~ GOTO ZDBAE100
-  IF ~~ THEN REPLY ~Whatever mischief you're initiating, I want no part in it.~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1) SetGlobal("ZDBAE_SHUTUP","GLOBAL",1)~ GOTO ZDBAEFU
+  IF ~Global("BA_BEGIN","GLOBAL",1)~ THEN REPLY ~Baeloth, we travelled together before. Surely you remember me?~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1)~ GOTO ZDBAE3
+  IF ~Global("BA_BEGIN","GLOBAL",1)~ THEN REPLY ~If it isn't my least favorite megalomaniac. Don't you remember me, drow?~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1)~ GOTO ZDBAE3
+  IF ~~ THEN REPLY ~Die, drow!~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1)~ GOTO ZDBAE100
+  IF ~~ THEN REPLY ~Whatever mischief you're planning, I'll play no part in it.~ DO ~SetGlobal("ZDBAE_BEGIN","GLOBAL",1) SetGlobal("ZDBAE_SHUTUP","GLOBAL",1)~ GOTO ZDBAEFU
 END
 
 IF ~!Global("ZDBAE_HOSTILE","GLOBAL",1) Global("ZDBAE_BEGIN","GLOBAL",1) Global("ZDBAE_SHUTUP","GLOBAL",1)~ THEN BEGIN ZDBAES
-  SAY ~Eh? What do YOU want?~
-  IF ~~ THEN REPLY ~Well met, I am <CHARNAME>.~ GOTO ZDBAE2
-  IF ~Global("BA_BEGIN","GLOBAL",1)~ THEN REPLY ~Baeloth! Do you remember me?~ GOTO ZDBAE3
+  SAY ~Eh? What do YOU want?~ [zdbaef]
+  IF ~~ THEN REPLY ~I could use your skills. Perhaps you'd consider joining me?~ GOTO ZDBAE5
   IF ~~ THEN REPLY ~I want you to die, drow!~DO ~SetGlobal("ZDBAE_REVEAL","GLOBAL",1)~ GOTO ZDBAE100
-  IF ~~ THEN REPLY ~I am not interested in your dog and pony show, drow.~ GOTO ZDBAEC
+  IF ~~ THEN REPLY ~I am not interested in your dog and pony show.~ GOTO ZDBAEC
 END
 
 // Confused
 IF ~~ BEGIN ZDBAEC
-  SAY ~But, but, my equine and lupus burlesque pageant draws distinguished Drow from all over ... nevermind. In any event, should you reconsider your ridiculous refrain, I'll remain here.~
+  SAY ~But, but - my equine-and-lupus burlesque pageant draws distinguished drow from all over! In any event, should you tire of these tedious refusals, I shall remain here.~
   IF ~~ THEN EXIT
 END
 
 // Hello
 IF ~~ THEN BEGIN ZDBAE2
-  SAY ~Is this what passes for perverse entertainment? Pitiable! Poorly played! Pathetic! What a paltry pit fight.~
-  IF ~~ THEN REPLY ~If it's real entertainment you're seeking, perhaps you'll join my party instead?~ GOTO ZDBAE5
-  IF ~~ THEN REPLY ~I am not interested your entertainment.~DO ~SetGlobal("ZDBAE_SHUTUP","GLOBAL",1)~ GOTO ZDBAEFU
+  SAY ~<CHARNAME>, tell me, is this what passes for perverse entertainment? Pitiful! Poorly played! Pathetic! What a paltry pit fight.~
+  IF ~~ THEN REPLY ~If you want real entertainment, perhaps you'll consider joining me?~ GOTO ZDBAE5
+  IF ~~ THEN REPLY ~I've no patience for this prattle.~ DO ~SetGlobal("ZDBAE_SHUTUP","GLOBAL",1)~ GOTO ZDBAEFU
 END
 
 IF ~~ THEN BEGIN ZDBAEFU
@@ -37,19 +37,20 @@ END
 
 // Remember
 IF ~~ THEN BEGIN ZDBAE3
-  SAY~Ah, absolutely! How could one ever forget a countenance as... delicately distinctive as yours? Regardless, rest assured that I would never disregard the delightful pleasure of your companionship, revelling in the glory that is, well... me.~
-  IF ~Global("BPINBG","GLOBAL",1)~ THEN REPLY ~You should, Baeloth! Don't you recognize your former champion?~ GOTO ZDBAE4
-  IF ~~ THEN REPLY ~You don't remember me at all do you?~ GOTO ZDBAE4
+  SAY~Ah, absolutely! How could one forget a countenance as... delicately distinctive as yours? Regardless, rest assured that I would never disregard the delightful pleasure of your company, revelling in the glory that is, well... me.~
+  IF ~Global("BPINBG","GLOBAL",1)~ THEN REPLY ~You ought to remember. After all, I am your former champion.~ GOTO ZDBAE4
+  IF ~~ THEN REPLY ~You don't remember me at all, do you?~ GOTO ZDBAE4
 END
 
 IF ~~ THEN BEGIN ZDBAE4
-  SAY ~My mirthful mate, let's not meander in minor matters. I am a dashing drow of discernment and delicious taste, indeed!~
-  IF ~~ THEN REPLY ~If it's real entertainment you're seeking, perhaps you'll join my party instead?~ GOTO ZDBAE5
+  SAY ~My mirthful mate, let's not meander over minor matters. I am a dashing drow of discernment and delicious taste indeed!~
+  IF ~~ THEN REPLY ~I suppose your skills may be useful. Perhaps you'll consider joining me?~ GOTO ZDBAE5
+  IF ~~ THEN REPLY ~I don't need your company, Baeloth.~ GOTO ZDBAEFU
 END
 
 // Reject
 IF ~~ THEN BEGIN ZDBAE5
-  SAY ~No, no, no. I wish for splendour and spectacle. Not parading around about in the public housing districts, with... What did you say your name was again? No, you shall bear witness to my new atmospheric arena.~
+  SAY ~No, no, no. I wish for splendor and spectacle. Not cavorting amongst the common rabble with...What did you say your name was again? Instead, you shall bear witness as this arena falls under my dazzling dominion!~
   IF ~~ THEN GOTO ZDBAE7
 END
 
@@ -62,40 +63,28 @@ END
 // Rescue
 IF ~!Global("ZDBAE_HOSTILE","GLOBAL",1) Global("ZDBAE_REVEAL","GLOBAL",2)~ THEN BEGIN ZDBAE8
   SAY ~Upon further reflection, I reconsider. I shall join your party of plenty after all. These misguided masses seem rather misinformed, don't you think? Let us be off, before Baeloth the Brilliant becomes Baeloth the Bludgeoned.~
-  IF ~~ THEN REPLY ~I accept this loose premise; let's hope your bark is as big as your bite.~ GOTO ZDBAE09
-  IF ~~ THEN REPLY ~I think I'd be more "entertained" by watching what these good people do to you!~ GOTO ZDBAE12
-  IF ~Global("BPINBG","GLOBAL",1)~ THEN REPLY ~My trust in you is thin, Baeloth, but if having you means another spellcaster at my side, then I'll agree for now.~ GOTO ZDBAE09
-  IF ~Global("BA_ATTACKED","LOCALS",1)~ THEN REPLY ~Travelling with me ended badly for you last time.~ GOTO ZDBAE10
-END
-
-// Accept
-IF ~~ THEN BEGIN ZDBAE09
-  SAY ~I sense the discerning glimmer of intelligence in those eyes. Yes, I can perceive your comprehension at my pernicious predicament. I would most heartily agree to aligning myself with your magnificence.~
-  IF ~~ THEN GOTO ZDBAE11
+  IF ~~ THEN REPLY ~I accept this loose premise; let's hope your bark is as big as your bite.~ GOTO ZDBAE11
+  IF ~~ THEN REPLY ~I think I'd be better entertained by watching what these people do to you.~ GOTO ZDBAE100
+  IF ~Global("BPINBG","GLOBAL",1)~ THEN REPLY ~My trust in you is thin, but I'll suffer your company for your spells.~ GOTO ZDBAE11
+  IF ~Global("BA_ATTACKED","LOCALS",1)~ THEN REPLY ~Our last travels together ended badly for you.~ GOTO ZDBAE10
 END
 
 // Uncertain
 IF ~~ THEN BEGIN ZDBAE10
-  SAY~It would be beneath you to so fervently fopp over a grudge for my erstwhile employment. Let bygones be bygones, as they say, Hmm?~
-  IF ~~ THEN REPLY ~My trust in you is thin, Baeloth, but if having you means another spellcaster at my side, then I'll agree for now.~ GOTO ZDBAE09
-  IF ~~ THEN REPLY ~'Oh Baeloth, bygones are not bygone.' Lets see what the misguided masses do to you now!~ GOTO ZDBAE12
-  IF ~Global("BPINBG","GLOBAL",1)~ THEN REPLY ~There is no forgetting what you did to me I am afraid! Lets see some "entertainment".~ GOTO ZDBAE12
+  SAY~Let bygones be bygones, as they say, hmm?~
+  IF ~~ THEN REPLY ~My trust in you is thin, but I'll suffer your company for your spells.~ GOTO ZDBAE11
+  IF ~~ THEN REPLY ~I think I'd be better entertained by watching what these people do to you.~ GOTO ZDBAE100
+  IF ~Global("BPINBG","GLOBAL",1)~ THEN REPLY ~You once trapped me in your pits, Baeloth. Let's see how you fare in this one.~ GOTO ZDBAE100
 END
 
 // Joins
 IF ~~ THEN BEGIN ZDBAE11
-  SAY ~Step spryly, my serendipitous sidekick! We've a spectacular show to splendidly stage, and the unintelligent will unwittingly waltz within our whimsical web. Oh, the poetic panorama of it all! They sought to stifle my spectacular self, but now they shall witness the wondrous weight of my wizardry!~
+  SAY ~Then step spryly, my serendipitous sidekick! We've a spectacular show to stage: the masses will marvel at the magic of Baeloth!~
   IF ~~ THEN DO ~SetGlobal("ZDBAE_JOINED","GLOBAL",1)~ EXIT
 END
 
-// Exit
-IF ~~ THEN BEGIN ZDBAE12
-  SAY ~It would be beneath you to so fervently fopp over a grudge for my erstwhile employment. Let bygones be bygones, as they say, Hmm?~
-  IF ~~ THEN GOTO ZDBAE100
-END
-
 IF ~~ THEN BEGIN ZDBAE100
-  SAY ~Oh, COME ON!~
+  SAY ~Oh, COME ON!~ [zdbae54]
   IF ~~ THEN DO ~
     SetGlobal("ZDBAE_HOSTILE","GLOBAL",1)
     ActionOverride("ZDBAE",ChangeAIScript("mage18c",CLASS))

--- a/zdbae/tra/english/setup.tra
+++ b/zdbae/tra/english/setup.tra
@@ -41,7 +41,7 @@
 @41   = ~I go... to my grave...~ [ZDBAE28]
 @42   = ~Such a flock of foliage flourishes around us!~ [ZDBAE29]
 @50   = ~Oh, COME ON!~ [ZDBAE54]
-@60   = ~Baeloth burns down the Copper Cornet and builds a new arena. In its ashes!~
+@60   = ~Baeloth burns down the Copper Cornet and builds a new arena. In its ashes!~ 
 @71   = ~Small Ring~
 @72   = ~Barrityl's Burden~
 @73   = ~This ring promises power at a great cost.~
@@ -86,9 +86,10 @@ The circumstances of his defeat within the pits are unclear; he claims dishonest
 @102 = ~WHAT?! Security, Security!~
 @103 = ~Burn the drow!~
 @104 = ~Kill the drow!~
-@105 = ~Good people I uh... Lets be reasonable about this!~
-@106 = ~What a wretched waste! How boring and banal this brawl is! Were I to grace these grounds with my talents, tragedy would instead transform into triumph. I would bring power, prestige and panache to this pitiful pit. Someone should displace - dare I say depose - of the dullard who dared to direct such a dreary display. Perhaps... me?~
+@105 = ~Good, uh, people. Surely we can resolve this with wit and not...whatever this is?~
+@106 = ~What a wretched waste! How boring and banal this brawl is! Were I to grace these grounds with my talents, tragedy would instead transform into triumph. I would bring power, prestige and panache to this pitiful pit.~
 @107 = ~You have the right of it.~
 @108 = ~I have not been entertained!~
 @109 = ~If you've got a plan, I'm in. Can't be much harder starting a fight than watching one.~
 @110 = ~Then huddle close my hapless horde. The time of tedium is about to be terminated.~
+@111 = ~Someone should displace - dare I say depose - of the dullard who dared to direct such a dreary display. Perhaps... me?~


### PR DESCRIPTION
- Cutscene won't start - thus infinite cutscene - because EscapeArea() was before it. That breaks ALL scripts or actions after it. I moved the troll's escape to the next cutscene.
- Nobles should now correctly say their lines.
- Baeloth's opening / joining dialogues have been edited.
- Played around with some line timing - but it still needs more tweaks.
-  Added a quick 'spell' effect when Baeloth tries to take over the area.